### PR TITLE
Update link to live map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sidewalk Widths San Jose
 
-[View the map here](https://www.codeforsanjose.com/sidewalk-widths/)
+[View the map here](https://codeforsanjose.github.io/sidewalk-widths/)
 
 This is a Mapbox-hosted map of the City of San José with a color-coded overlay of sidewalk widths, built in response to COVID-19. It was inspired by [Sidewalk Widths NYC](https://www.sidewalkwidths.nyc/) and uses the same color scheme. The sidewalk data was acquired from the Department of Public Works' [GIS Spatial Data Download](https://www.sanjoseca.gov/your-government/departments-offices/public-works/resources/gis-data-downloads) and processed with PostgreSQL.
 


### PR DESCRIPTION
codeforsanjose.org is no longer hosted by GitHub, so links should point to codeforsanjose.github.io instead.

/cc @impiaaa